### PR TITLE
Deploy da past doc para a branch gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 bower_components/
 
 *.log
+
+# Grunt gh-pages
+.grunt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,10 +74,17 @@
 						atBegin: true
 					}
 				}
+			},
+
+			'gh-pages': {
+				options: {
+					base: 'doc'
+				},
+				src: '**/*'
 			}
 		});
 
-		grunt.registerTask('default', ['concat', 'concat_css', 'cssmin', 'jsdoc', 'uglify']);
+		grunt.registerTask('default', ['concat', 'concat_css', 'cssmin', 'jsdoc', 'uglify', 'gh-pages']);
 
 		require('time-grunt')(grunt);
 		require('jit-grunt')(grunt);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-gh-pages": "^0.10.0",
     "grunt-jsdoc": "^0.6.3",
     "jit-grunt": "^0.9.1",
     "jsdoc-oblivion": "0.0.4",


### PR DESCRIPTION
Adicionei uma task no grunt para gerar o doc toda vez que rodar o grunt e manda-lo para a branch gh-pages.

Funcionou no fork e está online aqui: http://randsonjs.github.io/angular-maps/
